### PR TITLE
Use VcpkgNativePlugin to configure the project

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -91,7 +91,7 @@ lazy val vcpkg = crossProject(JVMPlatform, NativePlatform)
           conf.compileOptions ++ arch64
         )
     },
-  )
+  ).nativeConfigure(_.enablePlugins(VcpkgNativePlugin))
 
 lazy val brew = crossProject(JVMPlatform, NativePlatform)
   .crossType(CrossType.Pure)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,7 +8,7 @@ addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.1")
 
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.3.7" )
 
-addSbtPlugin("com.indoorvivants.vcpkg" % "sbt-vcpkg" % "0.0.11")
+addSbtPlugin("com.indoorvivants.vcpkg" % "sbt-vcpkg-native" % "0.0.11")
 addSbtPlugin("com.indoorvivants" % "bindgen-sbt-plugin" % "0.0.17")
 
 addSbtPlugin("com.armanbilge" % "sbt-scala-native-config-brew-github-actions" % "0.1.2")


### PR DESCRIPTION
VcpkgPlugin itself can install dependencies, but it doesn't add compilation/linking parameters to `NativeConfig`

VcpkgNativePlugin does everything VcpkgPlugin does + configures NativeConfig: https://github.com/indoorvivants/sn-vcpkg#scala-native-integration